### PR TITLE
Add methods for SparseMatrixLNK and ExtendableSparseMatrix to Base.copy

### DIFF
--- a/src/ExtendableSparse.jl
+++ b/src/ExtendableSparse.jl
@@ -6,7 +6,8 @@ using Requires
 
 using DocStringExtensions
 
-
+import SparseArrays: rowvals, getcolptr, nonzeros
+import Base: copy
 
 include("sparsematrixcsc.jl")
 include("sparsematrixlnk.jl")

--- a/src/extendable.jl
+++ b/src/extendable.jl
@@ -394,3 +394,10 @@ function SparseArrays.dropzeros!(ext::ExtendableSparseMatrix)
 end
 
 
+function copy(S::ExtendableSparseMatrix)
+    if isnothing(S.lnkmatrix)
+        ExtendableSparseMatrix(copy(S.cscmatrix), nothing, S.phash)
+    else
+        ExtendableSparseMatrix(copy(S.cscmatrix), copy(S.lnkmatrix), S.phash)
+    end
+end

--- a/src/sparsematrixlnk.jl
+++ b/src/sparsematrixlnk.jl
@@ -409,3 +409,10 @@ function SparseArrays.SparseMatrixCSC(lnk::SparseMatrixLNK)::SparseMatrixCSC
     csc=spzeros(lnk.m,lnk.n)
     lnk+csc
 end
+
+
+rowvals(S::SparseMatrixLNK) = getfield(S, :rowval)
+getcolptr(S::SparseMatrixLNK) = getfield(S, :colptr)
+nonzeros(S::SparseMatrixLNK) = getfield(S, :nzval)
+
+copy(S::SparseMatrixLNK) = SparseMatrixLNK(size(S, 1), size(S, 2), S.nnz, S.nentries, copy(getcolptr(S)), copy(rowvals(S)), copy(nonzeros(S)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,20 @@ using IterativeSolvers
     @test test_constructors()
 end
 
+##############################################################
+@testset "Copy-Methods" begin
+    function test_copymethods()
+        Xcsc = sprand(10_000,10_000,0.01)
+        Xlnk = SparseMatrixLNK(Xcsc)
+        Xext = ExtendableSparseMatrix(Xcsc)
+        t0 = @elapsed copy(Xcsc)
+        t1 = @elapsed copy(Xlnk)
+        t2 = @elapsed copy(Xext)
+        t1 / t0 < 10 && t0 / t2 < 10
+    end
+    @test test_copymethods()
+end
+
 #################################################################
 
 @testset "Updates" begin


### PR DESCRIPTION
This pull request fixes issue #14. I added methods for `SparseMatrixLNK` and `ExtendableSparseMatrix` to `Base.copy`. In order to mimic the definition for `SparseMatrixCSC`, I also added methods for `rowvals`, `getcolptr` and `nonzeros` from `SparseArrays`.