### PR TITLE
Add additional construcor for GenericExtendableSparsrMatrixCSC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## [2.5.0] - 2026-07-14
+- Add constructor for GenericExtendablSparseMatrixCSC from SparseMatrixCSC data
 
 ## [2.4.0] - 2026-07-12
 - JacobiPreconBuilder now allows for blocksize

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ExtendableSparse"
 uuid = "95c220a8-a1cf-11e9-0c77-dbfce5f500b3"
-version = "2.4.1"
+version = "2.5.0"
 authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Daniel Runge"]
 
 [deps]

--- a/src/genericextendablesparsematrixcsc.jl
+++ b/src/genericextendablesparsematrixcsc.jl
@@ -26,6 +26,13 @@ function GenericExtendableSparseMatrixCSC{Tm, Tv, Ti}(m::Integer, n::Integer) wh
     )
 end
 
+function GenericExtendableSparseMatrixCSC{Tm, Tv, Ti}(m::Integer, n::Integer, colptr::Vector{Ti}, rowvals::Vector{Ti}, nzval::Vector{Tv}) where {Tm <: AbstractSparseMatrixExtension, Tv, Ti <: Integer}
+    return GenericExtendableSparseMatrixCSC(
+        SparseMatrixCSC(m, n, colptr, rowvals, nzval),
+        Tm(m, n)
+    )
+end
+
 function GenericExtendableSparseMatrixCSC{Tm, Tv, Ti}(A::SparseMatrixCSC{Tv, Ti}) where {Tm <: AbstractSparseMatrixExtension, Tv, Ti <: Integer}
     return GenericExtendableSparseMatrixCSC{Tm, Tv, Ti}(
         SparseMatrixCSC(A),


### PR DESCRIPTION
This is used for Base.unaliascopy which is used by OrdinaryDiffeq.
